### PR TITLE
Custom survey input

### DIFF
--- a/btk/create_observing_generator.py
+++ b/btk/create_observing_generator.py
@@ -22,16 +22,22 @@ class ObservingGenerator:
                              survey_name are used to create the observing_generator.
         """
         if type(surveys) == str:
-            self.surveys = [surveys]
+            self.surveys = [all_surveys[surveys]]
         elif type(surveys) == list:
-            self.surveys = surveys
-        else:
-            raise TypeError("survey_name is not in the right format")
-        self.verbose = verbose
+            self.surveys = []
+            for s in surveys:
+                if type(s) == str:
+                    if s not in all_surveys:
+                        raise KeyError("Survey not implemented.")
+                    self.surveys.append(all_surveys[s])
+                elif type(s) == dict:
+                    self.surveys.append(s)
+                else:
+                    raise TypeError("surveys is not in the right format")
 
-        for s in self.surveys:
-            if s not in all_surveys:
-                raise KeyError("Survey not implemented.")
+        else:
+            raise TypeError("surveys is not in the right format")
+        self.verbose = verbose
 
         # create default observing conditions
         if obs_conds is None:
@@ -50,8 +56,8 @@ class ObservingGenerator:
     def __next__(self):
         observing_generator = {}
         for s in self.surveys:
-            observing_generator[s] = []
-            for band in all_surveys[s]["bands"]:
+            observing_generator[s["name"]] = []
+            for band in s["bands"]:
                 cutout = self.obs_conds(s, band)
-                observing_generator[s].append(cutout)
+                observing_generator[s["name"]].append(cutout)
         return observing_generator

--- a/btk/draw_blends.py
+++ b/btk/draw_blends.py
@@ -110,8 +110,8 @@ class DrawBlendsGenerator(ABC):
         self.bands = {}  # map from survey name to band.
         self.meas_bands = {}
         for i, s in enumerate(self.surveys):
-            self.bands[s] = all_surveys[s]["bands"]
-            self.meas_bands[s] = meas_bands[i]
+            print(s)
+            self.meas_bands[s["name"]] = meas_bands[i]
 
         self.add_noise = add_noise
         self.min_snr = min_snr
@@ -130,21 +130,21 @@ class DrawBlendsGenerator(ABC):
         blend_images = {}
         isolated_images = {}
         for s in self.surveys:
-            pix_stamp_size = int(self.stamp_size / all_surveys[s]["pixel_scale"])
-            blend_images[s] = np.zeros(
-                (self.batch_size, pix_stamp_size, pix_stamp_size, len(self.bands[s]))
+            pix_stamp_size = int(self.stamp_size / s["pixel_scale"])
+            blend_images[s["name"]] = np.zeros(
+                (self.batch_size, pix_stamp_size, pix_stamp_size, len(s["bands"]))
             )
 
-            isolated_images[s] = np.zeros(
+            isolated_images[s["name"]] = np.zeros(
                 (
                     self.batch_size,
                     self.max_number,
                     pix_stamp_size,
                     pix_stamp_size,
-                    len(self.bands[s]),
+                    len(s["bands"]),
                 )
             )
-            batch_blend_cat[s], batch_obs_cond[s] = [], []
+            batch_blend_cat[s["name"]], batch_obs_cond[s["name"]] = [], []
 
         in_batch_blend_cat = next(self.blend_generator)
         obs_conds = next(self.observing_generator)  # same for every blend in batch.
@@ -153,7 +153,7 @@ class DrawBlendsGenerator(ABC):
             input_args = [
                 (
                     copy.deepcopy(in_batch_blend_cat[i : i + mini_batch_size]),
-                    copy.deepcopy(obs_conds[s]),
+                    copy.deepcopy(obs_conds[s["name"]]),
                     s,
                 )
                 for i in range(0, self.batch_size, mini_batch_size)
@@ -174,9 +174,9 @@ class DrawBlendsGenerator(ABC):
 
             # organize results.
             for i in range(self.batch_size):
-                blend_images[s][i] = batch_results[i][0]
-                isolated_images[s][i] = batch_results[i][1]
-                batch_blend_cat[s].append(batch_results[i][2])
+                blend_images[s["name"]][i] = batch_results[i][0]
+                isolated_images[s["name"]][i] = batch_results[i][1]
+                batch_blend_cat[s["name"]].append(batch_results[i][2])
         if len(self.surveys) > 1:
             output = {
                 "blend_images": blend_images,
@@ -185,7 +185,7 @@ class DrawBlendsGenerator(ABC):
                 "obs_condition": obs_conds,
             }
         else:
-            survey_name = self.surveys[0]
+            survey_name = self.surveys[0]["name"]
             output = {
                 "blend_images": blend_images[survey_name],
                 "isolated_images": isolated_images[survey_name],
@@ -287,7 +287,7 @@ class WLDGenerator(DrawBlendsGenerator):
         blend_image = blend_image_temp.array
         return blend_image, iso_image
 
-    def run_mini_batch(self, blend_list, cutouts, survey_name):
+    def run_mini_batch(self, blend_list, cutouts, survey):
         """Returns isolated and blended images for bend catalogs in blend_list
 
         Function loops over blend_list and draws blend and isolated images in each
@@ -314,11 +314,11 @@ class WLDGenerator(DrawBlendsGenerator):
         for i in range(len(blend_list)):
 
             # All bands in same survey have same pixel scale, WCS
-            pixel_scale = all_surveys[survey_name]["pixel_scale"]
+            pixel_scale = survey["pixel_scale"]
             wcs = cutouts[0].wcs
 
             # Band to do measurements of size for given survey.
-            meas_band = self.meas_bands[survey_name]
+            meas_band = self.meas_bands[survey["name"]]
 
             dx, dy = get_center_in_pixels(blend_list[i], wcs)
             blend_list[i].add_column(dx)
@@ -326,7 +326,7 @@ class WLDGenerator(DrawBlendsGenerator):
             size = get_size(
                 pixel_scale,
                 blend_list[i],
-                cutouts[self.bands[survey_name] == meas_band],
+                cutouts[survey["bands"] == meas_band],
             )
             blend_list[i].add_column(size)
             pix_stamp_size = int(self.stamp_size / pixel_scale)
@@ -335,15 +335,15 @@ class WLDGenerator(DrawBlendsGenerator):
                     self.max_number,
                     pix_stamp_size,
                     pix_stamp_size,
-                    len(self.bands[survey_name]),
+                    len(survey["bands"]),
                 )
             )
             blend_image_multi = np.zeros(
-                (pix_stamp_size, pix_stamp_size, len(self.bands[survey_name]))
+                (pix_stamp_size, pix_stamp_size, len(survey["bands"]))
             )
-            for j in range(len(self.bands[survey_name])):
+            for j in range(len(survey["bands"])):
                 single_band_output = self.run_single_band(
-                    blend_list[i], cutouts[j], self.bands[survey_name][j]
+                    blend_list[i], cutouts[j], survey["bands"][j]
                 )
                 blend_image_multi[:, :, j] = single_band_output[0]
                 iso_image_multi[:, :, :, j] = single_band_output[1]

--- a/btk/draw_blends.py
+++ b/btk/draw_blends.py
@@ -110,7 +110,6 @@ class DrawBlendsGenerator(ABC):
         self.bands = {}  # map from survey name to band.
         self.meas_bands = {}
         for i, s in enumerate(self.surveys):
-            print(s)
             self.meas_bands[s["name"]] = meas_bands[i]
 
         self.add_noise = add_noise

--- a/btk/obs_conditions.py
+++ b/btk/obs_conditions.py
@@ -5,10 +5,11 @@ import btk.cutout
 
 
 all_surveys = {
-    "LSST": {"bands": ("y", "z", "i", "r", "g", "u"), "pixel_scale": 0.2},
-    "DES": {"bands": ("i", "r", "g", "z"), "pixel_scale": 0.263},
-    "CFHT": {"bands": ("i", "r"), "pixel_scale": 0.185},
+    "LSST": {"name": "LSST","bands": ("y", "z", "i", "r", "g", "u"), "pixel_scale": 0.2},
+    "DES": {"name": "DES","bands": ("i", "r", "g", "z"), "pixel_scale": 0.263},
+    "CFHT": {"name": "CFHT","bands": ("i", "r"), "pixel_scale": 0.185},
     "HSC": {
+        "name": "HSC",
         "bands": (
             "y",
             "z",
@@ -59,9 +60,9 @@ class WLDObsConditions(ObsConditions):
             **cutout_params
         )
 
-    def __call__(self, survey_name, band):
-        pixel_scale = all_surveys[survey_name]["pixel_scale"]
-        cutout = self.get_cutout(survey_name, band, pixel_scale)
+    def __call__(self, survey, band):
+        pixel_scale = survey["pixel_scale"]
+        cutout = self.get_cutout(survey["name"], band, pixel_scale)
 
         if cutout.pixel_scale != pixel_scale:
             raise ValueError(

--- a/btk/obs_conditions.py
+++ b/btk/obs_conditions.py
@@ -5,9 +5,13 @@ import btk.cutout
 
 
 all_surveys = {
-    "LSST": {"name": "LSST","bands": ("y", "z", "i", "r", "g", "u"), "pixel_scale": 0.2},
-    "DES": {"name": "DES","bands": ("i", "r", "g", "z"), "pixel_scale": 0.263},
-    "CFHT": {"name": "CFHT","bands": ("i", "r"), "pixel_scale": 0.185},
+    "LSST": {
+        "name": "LSST",
+        "bands": ("y", "z", "i", "r", "g", "u"),
+        "pixel_scale": 0.2,
+    },
+    "DES": {"name": "DES", "bands": ("i", "r", "g", "z"), "pixel_scale": 0.263},
+    "CFHT": {"name": "CFHT", "bands": ("i", "r"), "pixel_scale": 0.185},
     "HSC": {
         "name": "HSC",
         "bands": (

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -199,3 +199,70 @@ def test_custom_survey_input():
     assert draw_output["blend_images"]["DES"][0].shape[0] == int(
         24.0 / 0.263
     ), "DES survey should have a pixel scale of 0.17"
+
+def test_wrong_format():
+    with pytest.raises(TypeError):
+        catalog_name = "data/sample_input_catalog.fits"
+
+        np.random.seed(0)
+        stamp_size = 24.0
+        batch_size = 8
+        cpus = 1
+        multiprocessing = False
+        add_noise = True
+
+        catalog = btk.get_input_catalog.load_catalog(catalog_name)
+        sampling_function = btk.sampling_functions.DefaultSampling(stamp_size=stamp_size)
+        blend_generator = btk.create_blend_generator.BlendGenerator(
+            catalog, sampling_function, batch_size
+        )
+        obs_conds = btk.obs_conditions.DefaultObsConditions(stamp_size)
+        observing_generator = btk.create_observing_generator.ObservingGenerator(
+            [
+                ("LSST",("y", "z", "i", "r", "g", "u"),0.2),
+                {"name": "DES", "bands": ("i", "r", "g", "z"), "pixel_scale": 0.263},
+            ],
+            obs_conds=obs_conds,
+        )
+        draw_generator = btk.draw_blends.WLDGenerator(
+            blend_generator,
+            observing_generator,
+            multiprocessing=multiprocessing,
+            cpus=cpus,
+            add_noise=add_noise,
+            meas_bands=("i", "i"),
+        )
+        draw_output = next(draw_generator)
+
+def test_wrong_name():
+    with pytest.raises(KeyError):
+        catalog_name = "data/sample_input_catalog.fits"
+
+        np.random.seed(0)
+        stamp_size = 24.0
+        batch_size = 8
+        cpus = 1
+        multiprocessing = False
+        add_noise = True
+
+        catalog = btk.get_input_catalog.load_catalog(catalog_name)
+        sampling_function = btk.sampling_functions.DefaultSampling(stamp_size=stamp_size)
+        blend_generator = btk.create_blend_generator.BlendGenerator(
+            catalog, sampling_function, batch_size
+        )
+        obs_conds = btk.obs_conditions.DefaultObsConditions(stamp_size)
+        observing_generator = btk.create_observing_generator.ObservingGenerator(
+            [
+                "LSSD"
+            ],
+            obs_conds=obs_conds,
+        )
+        draw_generator = btk.draw_blends.WLDGenerator(
+            blend_generator,
+            observing_generator,
+            multiprocessing=multiprocessing,
+            cpus=cpus,
+            add_noise=add_noise,
+            meas_bands=("i", "i"),
+        )
+        draw_output = next(draw_generator)

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -147,3 +147,55 @@ def test_multiresolution():
     assert draw_output["blend_images"]["HSC"][0].shape[0] == int(
         24.0 / 0.17
     ), "HSC survey should have a pixel scale of 0.17"
+
+
+@pytest.mark.timeout(10)
+def test_custom_survey_input():
+    catalog_name = "data/sample_input_catalog.fits"
+
+    np.random.seed(0)
+    stamp_size = 24.0
+    batch_size = 8
+    cpus = 1
+    multiprocessing = False
+    add_noise = True
+
+    catalog = btk.get_input_catalog.load_catalog(catalog_name)
+    sampling_function = btk.sampling_functions.DefaultSampling(stamp_size=stamp_size)
+    blend_generator = btk.create_blend_generator.BlendGenerator(
+        catalog, sampling_function, batch_size
+    )
+    obs_conds = btk.obs_conditions.DefaultObsConditions(stamp_size)
+    observing_generator = btk.create_observing_generator.ObservingGenerator(
+        [
+            {
+                "name": "LSST",
+                "bands": ("u", "g", "r", "i", "z", "y"),
+                "pixel_scale": 0.2,
+            },
+            {"name": "DES", "bands": ("i", "r", "g", "z"), "pixel_scale": 0.263},
+        ],
+        obs_conds=obs_conds,
+    )
+    draw_generator = btk.draw_blends.WLDGenerator(
+        blend_generator,
+        observing_generator,
+        multiprocessing=multiprocessing,
+        cpus=cpus,
+        add_noise=add_noise,
+        meas_bands=("i", "i"),
+    )
+    draw_output = next(draw_generator)
+
+    assert (
+        "LSST" in draw_output["blend_list"].keys()
+    ), "Both surveys get well defined outputs"
+    assert (
+        "DES" in draw_output["blend_list"].keys()
+    ), "Both surveys get well defined outputs"
+    assert draw_output["blend_images"]["LSST"][0].shape[0] == int(
+        24.0 / 0.2
+    ), "LSST survey should have a pixel scale of 0.2"
+    assert draw_output["blend_images"]["DES"][0].shape[0] == int(
+        24.0 / 0.263
+    ), "DES survey should have a pixel scale of 0.17"

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -200,6 +200,7 @@ def test_custom_survey_input():
         24.0 / 0.263
     ), "DES survey should have a pixel scale of 0.17"
 
+
 def test_wrong_format():
     with pytest.raises(TypeError):
         catalog_name = "data/sample_input_catalog.fits"
@@ -212,14 +213,16 @@ def test_wrong_format():
         add_noise = True
 
         catalog = btk.get_input_catalog.load_catalog(catalog_name)
-        sampling_function = btk.sampling_functions.DefaultSampling(stamp_size=stamp_size)
+        sampling_function = btk.sampling_functions.DefaultSampling(
+            stamp_size=stamp_size
+        )
         blend_generator = btk.create_blend_generator.BlendGenerator(
             catalog, sampling_function, batch_size
         )
         obs_conds = btk.obs_conditions.DefaultObsConditions(stamp_size)
         observing_generator = btk.create_observing_generator.ObservingGenerator(
             [
-                ("LSST",("y", "z", "i", "r", "g", "u"),0.2),
+                ("LSST", ("y", "z", "i", "r", "g", "u"), 0.2),
                 {"name": "DES", "bands": ("i", "r", "g", "z"), "pixel_scale": 0.263},
             ],
             obs_conds=obs_conds,
@@ -234,6 +237,7 @@ def test_wrong_format():
         )
         draw_output = next(draw_generator)
 
+
 def test_wrong_name():
     with pytest.raises(KeyError):
         catalog_name = "data/sample_input_catalog.fits"
@@ -246,15 +250,15 @@ def test_wrong_name():
         add_noise = True
 
         catalog = btk.get_input_catalog.load_catalog(catalog_name)
-        sampling_function = btk.sampling_functions.DefaultSampling(stamp_size=stamp_size)
+        sampling_function = btk.sampling_functions.DefaultSampling(
+            stamp_size=stamp_size
+        )
         blend_generator = btk.create_blend_generator.BlendGenerator(
             catalog, sampling_function, batch_size
         )
         obs_conds = btk.obs_conditions.DefaultObsConditions(stamp_size)
         observing_generator = btk.create_observing_generator.ObservingGenerator(
-            [
-                "LSSD"
-            ],
+            ["LSSD"],
             obs_conds=obs_conds,
         )
         draw_generator = btk.draw_blends.WLDGenerator(


### PR DESCRIPTION
Fixes the issue #58 

Instead of storing the survey names, we now store the dictionary corresponding to the survey, either taken from `all_surveys` if the name of the survey is provided or directly given by the user. 