### PR TITLE
Refactor the Catalog objects

### DIFF
--- a/btk/catalog.py
+++ b/btk/catalog.py
@@ -6,72 +6,88 @@ import astropy.table
 
 
 class Catalog(ABC):
-    def __init__(self, catalog_file, selection_function=lambda x: x, verbose=False):
+    def __init__(self, catalog, verbose=False):
         """Returns astropy table with catalog name from input class.
 
         Args:
-            catalog_file: File path of CatSim-like catalog or galsim COSMOS catalog to
-                         draw galaxies from.
-            selection_function: Selection cuts (if input) to place on input catalog.
+            catalog : CatSim-like catalog or galsim COSMOS catalog to draw galaxies from.
             verbose: Whether to print information related to loading catalog.
 
         Attributes:
-            self.cat (varies): Catalog object of varying type. Might be necessary to
-                                ultimately generate the images (e.g. COSMOS Catalog)
-            self.table (`astropy.table`): CatSim-like catalog with a selection
-                                           criteria applied if provided.
+            self.table (`astropy.table`): CatSim-like catalog with selection criteria applied 
+                and recorded in the `_selection_functions` list.
         """
-        self.cat = self.get_catalog(catalog_file)
-        self.table = selection_function(self.get_table())
+        self._raw_catalog = catalog
         self.verbose = verbose
+        self.table = self._prepare_table()
+        self._selection_functions = []
 
         if self.verbose:
             print("Catalog loaded")
 
     @abstractmethod
-    def get_catalog(self, catalog_file):
+    @classmethod
+    def from_file(cls, catalog_file, verbose):
+        """Catalog constructor from input file"""
         pass
 
     @abstractmethod
-    def get_table(self):
+    def _prepare_table(self):
+        """Operations to standardize the catalog table"""
         pass
 
-    @abstractmethod
     @property
     def name(self):
-        # class name
-        pass
+        return self.__class__.__name__
 
+    def get_raw_catalog(self):
+        return self._raw_catalog
+
+    def apply_selection_function(self, selection_function):
+        """Apply a selection cut to the current table.
+
+        Parameters
+        ----------
+        selection_function: callable 
+            logical selection on the catalog table columns/rows.
+
+        """
+        if not callable(selection_function):
+            raise TypeError("selection_function must be callable")
+
+        self.table = selection_function(self.table)
+        self._selection_functions.append(selection_function)
 
 class WLDCatalog(Catalog):
-    def get_catalog(self, catalog_file) -> astropy.table.Table:
+    @classmethod
+    def from_file(cls, catalog_file, verbose=False):
         # catalog returned is an astropy table.
         _, ext = os.path.splitext(catalog_file)
-        fmt = "fits" if ext == ".fits" else "ascii.basic"
-        cat = astropy.table.Table.read(catalog_file, format=fmt)
-        return cat
+        fmt = "fits" if ext.lower() == ".fits" else "ascii.basic"
+        catalog = astropy.table.Table.read(catalog_file, format=fmt)
+        
+        return cls(catalog, verbose=verbose)
 
-    def get_table(self):
-        table = deepcopy(self.cat)
+    def _prepare_table(self):
+        table = deepcopy(self._raw_catalog)
 
         # convert ra dec from degrees to arcsec in catalog.
         table["ra"] *= 3600
         table["dec"] *= 3600
 
-        return self.cat
-
-    @property
-    def name(self):
-        return "WLDCatalog"
+        return table
 
 
 class CosmosCatalog(Catalog):
-    def get_catalog(self, catalog_file) -> galsim.scene.COSMOSCatalog:
+    @classmethod
+    def from_file(cls, catalog_file, verbose=False):
         # This will return a COSMOSCatalog object.
-        return galsim.COSMOSCatalog(file_name=catalog_file)
+        catalog = galsim.COSMOSCatalog(file_name=catalog_file)
 
-    def get_table(self):
-        table = astropy.table.Table(self.cat.real_cat)
+        return cls(catalog, verbose=verbose)
+
+    def _prepare_table(self):
+        table = astropy.table.Table(self._raw_catalog.real_cat)
 
         # make notation for 'ra' and 'dec' standard across code.
         table.rename_column("RA", "ra")
@@ -80,8 +96,5 @@ class CosmosCatalog(Catalog):
         # convert ra dec from degrees to arcsec in catalog.
         table["ra"] *= 3600
         table["dec"] *= 3600
-        return table
 
-    @property
-    def name(self):
-        return "CosmosCatalog"
+        return table

--- a/btk/sampling_functions.py
+++ b/btk/sampling_functions.py
@@ -3,6 +3,8 @@ from abc import ABC, abstractmethod
 import numpy as np
 import astropy.table
 
+from btk.catalog import WLDCatalog
+
 
 def _get_random_center_shift(num_objects, maxshift):
     """Returns random shifts in x and y coordinates between + and - max-shift
@@ -175,7 +177,8 @@ class GroupSamplingFunction(SamplingFunction):
             wld_catalog_name: File path to a pre-analyzed WLD Catsim catalog.
         """
         super().__init__(max_number)
-        self.wld_catalog = astropy.table.Table.read(wld_catalog_name, format="fits")
+
+        self.wld_catalog = WLDCatalog.from_file(wld_catalog_name).get_raw_catalog()
         self.stamp_size = stamp_size
         self.pixel_scale = pixel_scale
         self.shift = shift
@@ -253,7 +256,7 @@ class GroupSamplingFunctionNumbered(SamplingFunction):
             wld_catalog_name: Same as GroupSamplingFunction
         """
         super().__init__(max_number)
-        self.wld_catalog = astropy.table.Table.read(wld_catalog_name, format="fits")
+        self.wld_catalog = WLDCatalog.from_file(wld_catalog_name).get_raw_catalog()
         self.stamp_size = stamp_size
         self.pixel_scale = pixel_scale
         self.group_id_count = 0

--- a/btk_input.py
+++ b/btk_input.py
@@ -281,8 +281,8 @@ def get_obs_generator(
     )
     if verbose:
         print(
-            f"Observing conditions generated using {observe_function_name}"
-            " function defined in {utils_filename}"
+            f"Observing conditions generated using {obs_conditions_name}"
+            f" function defined in {utils_filename}"
         )
     return observing_generator
 

--- a/btk_input.py
+++ b/btk_input.py
@@ -157,15 +157,17 @@ def get_catalog(user_config_dict, catalog_name, selection_function_name, verbose
     else:
         utils_filename = os.path.join(os.path.dirname(btk.__file__), "utils.py")
         selection_function = None
-    catalog = btk.catalog.load_catalog(
-        catalog_name, selection_function=selection_function
-    )
+    catalog = btk.catalog.WLDCatalog.from_file(catalog_name)
+    if selection_function is not None:
+        catalog.apply_selection_function(selection_function)
+    
     if verbose:
         print(
-            f"Loaded {param.catalog_name} catalog with "
+            f"Loaded {catalog_name} catalog with "
             f"{selection_function_name} selection "
             f"function defined in {utils_filename}"
         )
+
     return catalog
 
 
@@ -227,7 +229,7 @@ def get_blend_generator(
     )
     if verbose:
         print(
-            f"Blend generator draws from {param.catalog_name} catalog "
+            f"Blend generator draws from {catalog.name} catalog "
             f"with {sampling_function_name} sampling function defined "
             f" in {utils_filename}"
         )

--- a/notebooks/intro.ipynb
+++ b/notebooks/intro.ipynb
@@ -158,7 +158,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catalog_full = btk.get_input_catalog.load_catalog(catalog_name)\n",
+    "catalog = btk.catalog.WLDCatalog.from_file(catalog_name)\n",
+    "catalog_full = catalog.get_raw_catalog()\n",
     "\n",
     "# as you can see this is just a astropy table. \n",
     "print(type(catalog_full))\n",
@@ -223,8 +224,12 @@
    "outputs": [],
    "source": [
     "# After defining the function, you can use it like: \n",
-    "catalog = btk.get_input_catalog.load_catalog(catalog_name, selection_function=btk.utils.basic_selection_function)\n",
-    "len(catalog)"
+    "catalog = btk.catalog.WLDCatalog.from_file(catalog_name)\n",
+    "catalog.apply_selection_function(btk.utils.basic_selection_function)\n",
+    "\n",
+    "table = catalog.table\n",
+    "\n",
+    "len(table)"
    ]
   },
   {
@@ -242,7 +247,7 @@
    "source": [
     "# let's see if our selection function is making sense by doing some histograms with the provided utility function.\n",
     "labels = ['full', 'default_selection']\n",
-    "make_histograms(catalog_full['i_ab'], catalog['i_ab'], labels=labels, loc=2)\n",
+    "make_histograms(catalog_full['i_ab'], table['i_ab'], labels=labels, loc=2)\n",
     "plt.xlabel('i_ab', size=18)"
    ]
   },
@@ -460,7 +465,7 @@
    "source": [
     "# setup params and catalog \n",
     "catalog_name = os.path.join(os.path.dirname(os.getcwd()), 'data', 'sample_input_catalog.fits')\n",
-    "catalog = btk.get_input_catalog.load_catalog(catalog_name,selection_function=None)\n",
+    "catalog = btk.catalog.WLDCatalog.from_file(catalog_name)\n",
     "blend_generator = btk.create_blend_generator.BlendGenerator(catalog, btk.sampling_functions.DefaultSampling(), batch_size)\n",
     "observing_generator = btk.create_observing_generator.ObservingGenerator(survey_name, obs_conds=None, stamp_size=stamp_size)"
    ]
@@ -609,7 +614,7 @@
     "    np.random.seed(0)\n",
     "\n",
     "    #Load input catalog\n",
-    "    catalog = btk.get_input_catalog.load_catalog(catalog_name)\n",
+    "    catalog = btk.catalog.WLDCatalog.from_file(catalog_name)\n",
     "\n",
     "    #Generate catalogs of blended objects \n",
     "    blend_generator = btk.create_blend_generator.BlendGenerator(catalog,\n",
@@ -1038,7 +1043,7 @@
     "    np.random.seed(0)\n",
     "\n",
     "    #Load input catalog\n",
-    "    catalog = btk.get_input_catalog.load_catalog(catalog_name)\n",
+    "    catalog = btk.catalog.WLDCatalog.from_file(catalog_name)\n",
     "\n",
     "    #Generate catalogs of blended objects \n",
     "    blend_generator = btk.create_blend_generator.BlendGenerator(catalog,btk.sampling_functions.DefaultSampling(max_number,stamp_size),batch_size)\n",

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -29,7 +29,7 @@ def get_draw_generator(
     else:
         shifts = None
         indexes = None
-    catalog = btk.catalog.load_catalog(catalog_name)
+    catalog = btk.catalog.WLDCatalog.from_file(catalog_name)
     sampling_function = btk.sampling_functions.DefaultSampling(stamp_size=stamp_size)
     blend_generator = btk.create_blend_generator.BlendGenerator(
         catalog, sampling_function, batch_size, shifts=shifts, indexes=indexes
@@ -116,7 +116,7 @@ def test_multiresolution():
     multiprocessing = False
     add_noise = True
 
-    catalog = btk.catalog.load_catalog(catalog_name)
+    catalog = btk.catalog.WLDCatalog.from_file(catalog_name)
     sampling_function = btk.sampling_functions.DefaultSampling(stamp_size=stamp_size)
     blend_generator = btk.create_blend_generator.BlendGenerator(
         catalog, sampling_function, batch_size
@@ -160,7 +160,7 @@ def test_custom_survey_input():
     multiprocessing = False
     add_noise = True
 
-    catalog = btk.get_input_catalog.load_catalog(catalog_name)
+    catalog = btk.catalog.WLDCatalog.from_file(catalog_name)
     sampling_function = btk.sampling_functions.DefaultSampling(stamp_size=stamp_size)
     blend_generator = btk.create_blend_generator.BlendGenerator(
         catalog, sampling_function, batch_size
@@ -212,7 +212,7 @@ def test_wrong_format():
         multiprocessing = False
         add_noise = True
 
-        catalog = btk.get_input_catalog.load_catalog(catalog_name)
+        catalog = btk.catalog.WLDCatalog.from_file(catalog_name)
         sampling_function = btk.sampling_functions.DefaultSampling(
             stamp_size=stamp_size
         )
@@ -249,7 +249,7 @@ def test_wrong_name():
         multiprocessing = False
         add_noise = True
 
-        catalog = btk.get_input_catalog.load_catalog(catalog_name)
+        catalog = btk.catalog.WLDCatalog.from_file(catalog_name)
         sampling_function = btk.sampling_functions.DefaultSampling(
             stamp_size=stamp_size
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,7 @@ def get_draw_generator(batch_size=3):
     pixel_scale = 0.2
     shift = [0.8, -0.7]
     np.random.seed(0)
-    catalog = btk.catalog.load_catalog(catalog_name)
+    catalog = btk.catalog.WLDCatalog.from_file(catalog_name)
     blend_generator = btk.create_blend_generator.BlendGenerator(
         catalog,
         btk.sampling_functions.GroupSamplingFunctionNumbered(
@@ -52,7 +52,7 @@ def get_meas_generator(meas_params, multiprocessing=False, cpus=1):
         [[0.2, 2.4], [-1.8, -2.0]],
     ]
     indexes = [[4, 5], [9, 1], [9, 2], [0, 2], [3, 8], [0, 7], [10, 2], [0, 10]]
-    catalog = btk.catalog.load_catalog(catalog_name)
+    catalog = btk.catalog.WLDCatalog.from_file(catalog_name)
     blend_generator = btk.create_blend_generator.BlendGenerator(
         catalog,
         btk.sampling_functions.DefaultSampling(),


### PR DESCRIPTION
This PR aims at refactoring the current `Catalog` class to improve its modularity.

Among the changes:
- `__init__` signature changed to initialize the `Catalog` from an existing catalog-like object.
- use of a `@classmethod` to construct the `Catalog` from a file
- the raw catalog is now a private class attribute and should be accessed through the `get_raw_catalog()` method
- selection functions on the table can be passed through the `apply_selection_function()` method and are stored for inspection