### PR TITLE
Change the use of catalogs

### DIFF
--- a/notebooks/Gaslim_draw.ipynb
+++ b/notebooks/Gaslim_draw.ipynb
@@ -134,17 +134,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catalog_names = [os.path.join('/Users/remy/Desktop/LSST_Project/GalSim/examples/', \n",
-    "                            'data/COSMOS_25.2_training_sample', \n",
-    "                            'real_galaxy_catalog_25.2.fits'),\n",
-    "                 os.path.join('/Users/remy/Desktop/LSST_Project/GalSim/examples/', \n",
-    "                            'data/COSMOS_25.2_training_sample', \n",
-    "                            'real_galaxy_catalog_25.2_fits.fits')]\n",
-    "galsim_catalog = galsim.COSMOSCatalog(catalog_names[0])\n",
+    "# Change this to your own path to galsim 'real_galaxy_catalog_25.2.fits'\n",
+    "galsim path = '/Users/remy/Desktop/LSST_Project/GalSim/examples/data/COSMOS_25.2_training_sample'\n",
+    "                            \n",
+    "name = os.path.join(galsim path, 'real_galaxy_catalog_25.2.fits')\n",
+    "galsim_catalog = galsim.COSMOSCatalog(name)\n",
+    "catalog_name = os.path.join(os.path.dirname(os.getcwd()), 'data', 'sample_input_catalog.fits')\n",
     "max_number = 6 # Number of galaxies in a stamp\n",
     "batch_size = 2 # Number of stamps in a batch\n",
     "stamp_size = 24.0 # Size of the desired stamp, in arcsecs (default to 24.0)\n",
-    "survey= Roman\n",
+    "survey = Rubin\n",
     "\n",
     "np.random.seed(0)"
    ]
@@ -171,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catalog = btk.catalog.CosmosCatalog.from_file(catalog_names)\n",
+    "catalog = btk.catalog.WLDCatalog.from_file(catalog_name)\n",
     "catalog_full = catalog.get_raw_catalog()\n",
     "\n",
     "# as you can see this is just a astropy table. \n",
@@ -217,7 +216,7 @@
    "outputs": [],
    "source": [
     "# After defining the function, you can use it like: \n",
-    "catalog.apply_selection_function(btk.utils.basic_selection_function, 1, 25)\n",
+    "catalog.apply_selection_function(btk.utils.basic_selection_function, 4, 27)\n",
     "table = catalog.table\n",
     "len(table)"
    ]

--- a/notebooks/intro.ipynb
+++ b/notebooks/intro.ipynb
@@ -1192,7 +1192,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,


### PR DESCRIPTION
This is an arch-minor change that fixes the use of the catalog in the Cosmos generator. It is my fault for initially not understanding the role of the catalog correctly in BTK. Here I still use the WLD catalog to draw galaxy brightnesses. Their profiles are then drawn from the Cosmos catalog. What matter is that the blend-generator receives the WLD catalog to generate Rubin images. 
I haven't removed the `CosmosCatalog` class from the code as it could be useful to draw blends at HST resolution if we ever want to do that.