### PR TITLE
enable multiprocess function to use kwargs

### DIFF
--- a/btk/draw_blends.py
+++ b/btk/draw_blends.py
@@ -260,8 +260,8 @@ class DrawBlendsGenerator(ABC):
             mini_batch_results = multiprocess(
                 self.render_mini_batch,
                 input_args,
-                self.cpus,
-                self.verbose,
+                cpus=self.cpus,
+                verbose=self.verbose,
             )
 
             # join results across mini-batches.

--- a/btk/measure.py
+++ b/btk/measure.py
@@ -227,8 +227,8 @@ class MeasureGenerator:
         measure_results = multiprocess(
             self.run_batch,
             input_args,
-            self.cpus,
-            self.verbose,
+            cpus=self.cpus,
+            verbose=self.verbose,
         )
         if self.verbose:
             print("Measurement performed on batch")

--- a/btk/multiprocess.py
+++ b/btk/multiprocess.py
@@ -1,20 +1,48 @@
 """Tools for multiprocessing in BTK."""
 import multiprocessing as mp
+from itertools import repeat
 from itertools import starmap
 
 
-def multiprocess(func, input_args, cpus, verbose=False):
-    """Sole Function that implements multiprocessing across mini-batches for BTK."""
+def _apply_args_and_kwargs(fn, args, kwargs):
+    return fn(*args, **kwargs)
+
+
+def _pool_starmap_with_kwargs(pool, fn, args_iter, kwargs_iter):
+    args_for_starmap = zip(repeat(fn), args_iter, kwargs_iter)
+    return pool.starmap(_apply_args_and_kwargs, args_for_starmap)
+
+
+def _starmap_with_kwargs(fn, args_iter, kwargs_iter):
+    args_for_starmap = zip(repeat(fn), args_iter, kwargs_iter)
+    return starmap(_apply_args_and_kwargs, args_for_starmap)
+
+
+def multiprocess(fn, args_iter, kwargs_iter=None, cpus=1, verbose=False):
+    """Sole function that implements multiprocessing across mini-batches/batches for BTK.
+
+    Args:
+        fn (function): Function to run in parallel on each of the `input_args`.
+        args_iter (iter): Iterator returning arguments to be passed in to function for
+            multiprocessing. This iterator must have a `__len__` method implemented. Each
+            argument returned by the iterator must be unpackable like `*args`.
+        kwargs_iter (iter): Iterator returning keyword arguments to be passed in to
+            function for multiprocessing. Default is that no keyword arguments are passed in.
+            Each element returned by the iterator must be a `dict`.
+        cpus (int): # of cpus to use for multiprocessing.
+        verbose (bool): Whether to print information related to multiprocessing
+    """
+    kwargs_iter = repeat({}) if kwargs_iter is None else kwargs_iter
     if cpus > 1:
         if verbose:
             print(
-                f"Running mini-batch of size {len(input_args)} with multiprocessing with "
+                f"Running mini-batch of size {len(args_iter)} with multiprocessing with "
                 f"pool {cpus}"
             )
         with mp.Pool(processes=cpus) as pool:
-            results = pool.starmap(func, input_args)
+            results = _pool_starmap_with_kwargs(pool, fn, args_iter, kwargs_iter)
     else:
         if verbose:
-            print(f"Running mini-batch of size {len(input_args)} serial {cpus} times")
-        results = list(starmap(func, input_args))
+            print(f"Running mini-batch of size {len(args_iter)} serial {cpus} times")
+        results = list(_starmap_with_kwargs(fn, args_iter, kwargs_iter))
     return results

--- a/btk/multiprocess.py
+++ b/btk/multiprocess.py
@@ -22,13 +22,14 @@ def multiprocess(fn, args_iter, kwargs_iter=None, cpus=1, verbose=False):
     """Sole function that implements multiprocessing across mini-batches/batches for BTK.
 
     Args:
-        fn (function): Function to run in parallel on each of the `input_args`.
-        args_iter (iter): Iterator returning arguments to be passed in to function for
+        fn (function): Function to run in parallel on each positional arguments returned by
+            `args_iter` and each keyword arguments returned by `kwargs_iter`.
+        args_iter (iter): Iterator returning positional arguments to be passed in to function for
             multiprocessing. This iterator must have a `__len__` method implemented. Each
-            argument returned by the iterator must be unpackable like `*args`.
+            argument returned by the iterator must be unpackable like: `*args`.
         kwargs_iter (iter): Iterator returning keyword arguments to be passed in to
-            function for multiprocessing. Default is that no keyword arguments are passed in.
-            Each element returned by the iterator must be a `dict`.
+            function for multiprocessing. Default value `None` means that no keyword arguments
+            are passed in. Each element returned by the iterator must be a `dict`.
         cpus (int): # of cpus to use for multiprocessing.
         verbose (bool): Whether to print information related to multiprocessing
     """


### PR DESCRIPTION
This will be a useful way to enable `measure_functions` to be more general in an upcoming PR.