### PR TITLE
Fix measure channel last

### DIFF
--- a/btk/measure.py
+++ b/btk/measure.py
@@ -181,11 +181,12 @@ class MeasureGenerator:
         self.cpus = cpus
 
         self.batch_size = self.draw_blend_generator.batch_size
+        self.channels_last = self.draw_blend_generator.channels_last
         self.verbose = verbose
 
         # initialize measure_kwargs dictionary.
         self.measure_kwargs = {} if measure_kwargs is None else measure_kwargs
-        self.measure_kwargs["channels_last"] = self.draw_blend_generator.channels_last
+        self.measure_kwargs["channels_last"] = self.channels_last
 
     def __iter__(self):
         """Return iterator which is the object itself."""

--- a/btk/measure.py
+++ b/btk/measure.py
@@ -191,12 +191,12 @@ class MeasureGenerator:
         """Return iterator which is the object itself."""
         return self
 
-    def run_batch(self, batch, index):
+    def run_batch(self, batch, index, **kwargs):
         """Perform measurements on a single blend."""
         output = []
         for f in self.measure_functions:
 
-            out = f(batch, index)
+            out = f(batch, index, **kwargs)
 
             # make sure output is in the correct format.
             if not isinstance(out["catalog"], astropy.table.Table):

--- a/btk/measure.py
+++ b/btk/measure.py
@@ -1,9 +1,18 @@
 """File containing measurement infrastructure for the BlendingToolKit.
 
 Contains examples of functions that can be used to apply a measurement algorithm to the blends
-simulated by BTK. Every measurement function should take as an input a `batch` returned from a
-DrawBlendsGenerator object (see its `__next__` method) and an index corresponding to which image
-in the batch to measure.
+ simulated by BTK. Every measurement function should have the following skeleton:
+
+ ```
+def measure_function(batch, idx, **kwargs):
+    # do some measurements on the images contained in batch.
+    return output
+ ```
+
+where `batch` is the output from the `DrawBlendsGenerator` object (see its `__next__` method) and
+`idx` is the index corresponding to which image in the batch to measure. The additional keyword
+arguments `**kwargs` can be passed via the `measure_kwargs` dictionary argument in the
+`MeasureGerator` initialize which are shared among all the measurement functions.
 
 It should return a dictionary containing a subset of the following keys/values (note the key
 `catalog` is mandatory):

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -320,7 +320,8 @@ The measure function is a regular function with two positional arguments : `batc
 
     image = batch["blend_images"][idx]
     stamp_size = image.shape[-2]  # true for both 'NCHW' or 'NHWC' formats.
-    coadd = np.mean(image, axis=np.argmin(image.shape))  # Smallest dimension is the channels
+    channel_indx = 0 if not channels_last else -1
+    coadd = np.mean(image, axis=channel_indx)  # Smallest dimension is the channels
     bkg = sep.Background(coadd)
     # Here the 1.5 value corresponds to a 1.5 sigma threshold for detection against noise.
     catalog, segmentation = sep.extract(coadd, 1.5, err=bkg.globalrms, segmentation_map=True)

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -298,11 +298,11 @@ Measurement
 ............
 
 Now that we have some images, we can carry on with the measurements. What we call measurements in BTK is one of the three main targets of deblending : detections, segmentations and deblended images. You can use BTK to directly carry out the measurements on the generated data. To do this, you need to define a measure function.
-The measure function is a regular function with two arguments : `batch` and `idx`. Batch is the direct output of a `DrawBlendsGenerator`, and `idx` is the index of the blend on which the measurements should be done. Here is an example of what the function looks like for SEP (python implementation of Source Extractor).
+The measure function is a regular function with two positional arguments : `batch` and `idx`. Batch is the direct output of a `DrawBlendsGenerator`, and `idx` is the index of the blend on which the measurements should be done. It also takes an arbitrary number of keyword arguments via `**kwargs`. Here is an example of what the function looks like for SEP (python implementation of Source Extractor).
 
 .. jupyter-execute::
 
-  def sep_measure(batch, idx):
+  def sep_measure(batch, idx, channels_last=False, **kwargs):
     """Return detection, segmentation and deblending information with SEP.
 
     NOTE: This function does not support the multi-resolution feature.


### PR DESCRIPTION
This fixes a comment from @aboucaud in the most recent PR #125 and allows measurement functions to take an arbitrary number of keyword arguments. One downside is that the skeleton changed slightly, it is now required to be: 

 ```
def measure_function(batch, idx, **kwargs):
    # do some measurements on the images contained in batch.
    return output
 ```

since all the measure_functions share the keyword arguments passed in to the measure_generator initializer, so some measure_functions will get passed in keyword arguments that are not used. (open to suggestions) 