### PR TITLE
Added average precision (AUC) metric

### DIFF
--- a/btk/measure.py
+++ b/btk/measure.py
@@ -274,12 +274,12 @@ class MeasureGenerator:
             if self.verbose:
                 print(f"Measurement {m} performed on batch")
             for i, f in enumerate(self.measure_functions):
-                measure_dic = {}
+                measure_dict = {}
                 for key in ["catalog", "deblended_images", "segmentation"]:
                     if measure_output[0][i][key] is not None:
-                        measure_dic[key] = [
+                        measure_dict[key] = [
                             measure_output[j][i][key] for j in range(len(measure_output))
                         ]
-                measure_results[f.__name__ + str(m)] = measure_dic
+                measure_results[f.__name__ + str(m)] = measure_dict
 
         return blend_output, measure_results

--- a/btk/measure.py
+++ b/btk/measure.py
@@ -103,6 +103,7 @@ def sep_measure(batch, idx, channels_last=False, **kwargs):
     """
     if isinstance(batch["blend_images"], dict):
         raise NotImplementedError("This function does not support the multi-resolution feature.")
+    sigma_noise = kwargs.get("sigma_noise", 1.5)
 
     image = batch["blend_images"][idx]
     stamp_size = image.shape[-2]  # true for both 'NCHW' or 'NHWC' formats.
@@ -110,7 +111,9 @@ def sep_measure(batch, idx, channels_last=False, **kwargs):
     coadd = np.mean(image, axis=channel_indx)  # Smallest dimension is the channels
     bkg = sep.Background(coadd)
     # Here the 1.5 value corresponds to a 1.5 sigma threshold for detection against noise.
-    catalog, segmentation = sep.extract(coadd, 1.5, err=bkg.globalrms, segmentation_map=True)
+    catalog, segmentation = sep.extract(
+        coadd, sigma_noise, err=bkg.globalrms, segmentation_map=True
+    )
     n_objects = len(catalog)
     segmentation_exp = np.zeros((n_objects, stamp_size, stamp_size), dtype=bool)
     deblended_images = np.zeros((n_objects, *image.shape), dtype=image.dtype)
@@ -150,7 +153,7 @@ class MeasureGenerator:
         draw_blend_generator,
         cpus=1,
         verbose=False,
-        measure_kwargs: dict = None,
+        measure_kwargs: list = None,
     ):
         """Initialize measurement generator.
 
@@ -161,8 +164,10 @@ class MeasureGenerator:
                                   isolated images, blend catalog, wcs info, and psf.
             cpus: The number of parallel processes to run [Default: 1].
             verbose (bool): Whether to print information about measurement.
-            measure_kwargs (dict): Dictionary containing keyword arguments to be passed
-                in to each of the `measure_functions`.
+            measure_kwargs (list): list of dictionaries containing keyword arguments
+            to be passed in to each of the `measure_functions`. Each dictionnary is
+            passed one time to each function, meaning that each function which be
+            ran as many times as there are different dictionnaries.
         """
         # setup and verify measure_functions.
         if callable(measure_functions):
@@ -185,8 +190,9 @@ class MeasureGenerator:
         self.verbose = verbose
 
         # initialize measure_kwargs dictionary.
-        self.measure_kwargs = {} if measure_kwargs is None else measure_kwargs
-        self.measure_kwargs["channels_last"] = self.channels_last
+        self.measure_kwargs = [{}] if measure_kwargs is None else measure_kwargs
+        for m in self.measure_kwargs:
+            m["channels_last"] = self.channels_last
 
     def __iter__(self):
         """Return iterator which is the object itself."""
@@ -254,25 +260,26 @@ class MeasureGenerator:
                 the corresponding measure_function` for one batch.
         """
         blend_output = next(self.draw_blend_generator)
-        args_iter = ((blend_output, i) for i in range(self.batch_size))
-        kwargs_iter = repeat(self.measure_kwargs)
-        measure_output = multiprocess(
-            self.run_batch,
-            args_iter,
-            kwargs_iter=kwargs_iter,
-            cpus=self.cpus,
-            verbose=self.verbose,
-        )
-        if self.verbose:
-            print("Measurement performed on batch")
         measure_results = {}
-        for i, f in enumerate(self.measure_functions):
-            measure_dic = {}
-            for key in ["catalog", "deblended_images", "segmentation"]:
-                if measure_output[0][i][key] is not None:
-                    measure_dic[key] = [
-                        measure_output[j][i][key] for j in range(len(measure_output))
-                    ]
-            measure_results[f.__name__] = measure_dic
+        for m, measure_kwargs in enumerate(self.measure_kwargs):
+            args_iter = ((blend_output, i) for i in range(self.batch_size))
+            kwargs_iter = repeat(measure_kwargs)
+            measure_output = multiprocess(
+                self.run_batch,
+                args_iter,
+                kwargs_iter=kwargs_iter,
+                cpus=self.cpus,
+                verbose=self.verbose,
+            )
+            if self.verbose:
+                print(f"Measurement {m} performed on batch")
+            for i, f in enumerate(self.measure_functions):
+                measure_dic = {}
+                for key in ["catalog", "deblended_images", "segmentation"]:
+                    if measure_output[0][i][key] is not None:
+                        measure_dic[key] = [
+                            measure_output[j][i][key] for j in range(len(measure_output))
+                        ]
+                measure_results[f.__name__ + str(m)] = measure_dic
 
         return blend_output, measure_results

--- a/btk/metrics.py
+++ b/btk/metrics.py
@@ -738,6 +738,12 @@ def auc(metrics_results, measure_name, n_meas, plot=False, ax=None):
     recalls = np.array(recalls)[order]
     precisions = np.array(precisions)[order]
 
+    # The integral is from zero to one
+    recalls = np.insert(recalls, 0, 0)
+    precisions = np.insert(precisions, 0, precisions[0])
+    recalls = np.insert(recalls, -1, 1)
+    precisions = np.insert(precisions, -1, precisions[-1])
+
     for i in range(1, n_meas):
         average_precision += precisions[i] * (recalls[i] - recalls[i - 1])
 

--- a/btk/metrics.py
+++ b/btk/metrics.py
@@ -55,6 +55,7 @@ Currently, we support the following metrics :
 """
 import astropy.table
 import galsim
+import matplotlib.pyplot as plt
 import numpy as np
 import skimage.metrics
 from scipy.optimize import linear_sum_assignment
@@ -699,3 +700,51 @@ class MetricsGenerator:
             metrics_results[meas_func] = metrics_results_f
 
         return blend_results, measure_results, metrics_results
+
+
+def auc(metrics_results, measure_name, n_meas, plot=False, ax=None):
+    """Computes the average precision metric and plot the Precision-Recall curve.
+
+    The average precision is defined as the area under the precision-recall curve.
+    The precision-recall curve is obtained by running the same algorithm with
+    different thresholds, and plotting the curve with recall as the x axis
+    and precision as the y axis (see detection metrics for a definition of
+    precision and recall).
+    This should be used by providing a list of different kwargs to a measure
+    generator, proceed as usual, and give the results of the metrics generator
+    to this function.
+
+    Args:
+        metrics_results (dict): Output of a btk.metrics.MetricsGenerator.
+        measure_name (str): Base name of the measure function which will be
+                            evaluated.
+        n_meas (int): Number of different kwargs which were given.
+        plot (bool): Set to True to plot the precision-recall curve.
+        ax (matplotlib.axes.Axes): If plot is True, the results will be
+        drawn on this ax.
+
+    Returns:
+        An int corresponding to the average precision.
+
+    """
+    precisions = []
+    recalls = []
+    average_precision = 0
+    for i in range(n_meas):
+        metrics_results_temp = metrics_results[measure_name + str(i)]
+        precisions.append(metrics_results_temp["detection"]["precision"])
+        recalls.append(metrics_results_temp["detection"]["recall"])
+    order = np.argsort(recalls)
+    recalls = np.array(recalls)[order]
+    precisions = np.array(precisions)[order]
+
+    for i in range(1, n_meas):
+        average_precision += precisions[i] * (recalls[i] - recalls[i - 1])
+
+    if plot:
+        ax = plt.gca() if ax is None else ax
+        ax.scatter(recalls, precisions, label=measure_name)
+        ax.set_xlabel("Recall")
+        ax.set_ylabel("Precision")
+
+    return average_precision

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -78,11 +78,12 @@ def test_detection_eff_matrix():
     )
 
 
-def test_measure_kwargs():
+@patch("btk.plot_utils.plt.show")
+def test_measure_kwargs(mock_show):
     """Test detection with sep"""
     meas_generator = get_metrics_generator(
         btk.measure.sep_measure, measure_kwargs=[{"sigma_noise": 2.0}, {"sigma_noise": 3.0}]
     )
     _, _, results = next(meas_generator)
-    average_precision = btk.metrics.auc(results, "sep_measure", 2)
+    average_precision = btk.metrics.auc(results, "sep_measure", 2, plot=True)
     assert average_precision == 0.4375

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -6,7 +6,7 @@ import numpy as np
 import btk.metrics
 
 
-def get_metrics_generator(meas_function, cpus=1):
+def get_metrics_generator(meas_function, cpus=1, measure_kwargs=None):
     """Returns draw generator with group sampling function"""
 
     np.random.seed(0)
@@ -34,9 +34,7 @@ def get_metrics_generator(meas_function, cpus=1):
         stamp_size=stamp_size,
     )
     meas_generator = btk.measure.MeasureGenerator(
-        meas_function,
-        draw_blend_generator,
-        cpus=cpus,
+        meas_function, draw_blend_generator, cpus=cpus, measure_kwargs=measure_kwargs
     )
     metrics_generator = btk.metrics.MetricsGenerator(
         meas_generator,
@@ -78,3 +76,13 @@ def test_detection_eff_matrix():
     np.testing.assert_array_equal(
         eff_matrix, test_eff_matrix, err_msg="Incorrect efficiency matrix"
     )
+
+
+def test_measure_kwargs():
+    """Test detection with sep"""
+    meas_generator = get_metrics_generator(
+        btk.measure.sep_measure, measure_kwargs=[{"sigma_noise": 2.0}, {"sigma_noise": 3.0}]
+    )
+    _, _, results = next(meas_generator)
+    average_precision = btk.metrics.auc(results, "sep_measure", 2)
+    assert average_precision == 0.4375


### PR DESCRIPTION
Closes #146.

I implemented the approach described in the issue. This changes the following things : 
- measure_kwargs should be provided as a list of dictionaries instead of a dictionary (the measure function will be executed one time with each dictionary in the list)
- the end results are named `sep_measure0, sep_measure1...`, even in the case where only one or no kwargs were provided.

When the user provides multiple kwargs, he can give the metrics results to the `auc` function to compute the average precision and optionally plot the precision-recall curve.