### PR TITLE
Changed metrics default value to NaN

### DIFF
--- a/btk/metrics.py
+++ b/btk/metrics.py
@@ -108,6 +108,7 @@ def meas_ksb_ellipticity(image, additional_params):
             f"Shear measurement error : '{res.error_message }'. \
             This error may happen for faint galaxies or inaccurate detections."
         )
+        result = [np.nan, np.nan, np.nan]
     return result
 
 
@@ -328,7 +329,7 @@ def segmentation_metrics_blend(
                 / np.sum(np.logical_or(true_segmentation, detected_segmentation))
             )
         else:
-            iou_blend_results.append(-1)
+            iou_blend_results.append(np.nan)
     return iou_blend_results
 
 
@@ -448,11 +449,11 @@ def reconstruction_metrics_blend(
                     target_meas_blend_results[k].append(res_deblended)
                     target_meas_blend_results[k + "_true"].append(res_isolated)
         else:
-            msr_blend_results.append(-1)
-            psnr_blend_results.append(-1)
-            ssim_blend_results.append(-1)
+            msr_blend_results.append(np.nan)
+            psnr_blend_results.append(np.nan)
+            ssim_blend_results.append(np.nan)
             for k in target_meas_blend_results.keys():
-                target_meas_blend_results[k].append(-1)
+                target_meas_blend_results[k].append(np.nan)
 
     return msr_blend_results, psnr_blend_results, ssim_blend_results, target_meas_blend_results
 

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -73,7 +73,7 @@ class TestBasicDraw:
         the mean and std values in the batch. This is compared to the values
         measured a proiri for the default input settings.
         """
-        test_batch_max = np.array([90.721, 1245.693, 7636.189, 10329.56, 8506.056, 4772.817])
+        test_batch_max = np.array([90.721, 1245.694, 7636.193, 10329.563, 8506.06, 4772.819])
         test_batch_mean = 3.1101762559117585
         test_batch_std = 90.74182140645624
         batch_max = isolated_images.max(axis=(0, 1, 3, 4))

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -73,7 +73,7 @@ class TestBasicDraw:
         the mean and std values in the batch. This is compared to the values
         measured a proiri for the default input settings.
         """
-        test_batch_max = np.array([90.721, 1245.694, 7636.193, 10329.563, 8506.06, 4772.819])
+        test_batch_max = np.array([90.721, 1245.693, 7636.189, 10329.56, 8506.056, 4772.817])
         test_batch_mean = 3.1101762559117585
         test_batch_std = 90.74182140645624
         batch_max = isolated_images.max(axis=(0, 1, 3, 4))


### PR DESCRIPTION
Closes #141 

Instead of having inconsistent values for the metrics when they could not be computed, the value is now NaN. I am not sure if it is necessary to allow for the user to change it.

