### PR TITLE
Ensure PSF is consistently propagated if customized

### DIFF
--- a/btk/main.py
+++ b/btk/main.py
@@ -7,12 +7,12 @@ from omegaconf import OmegaConf
 from btk.measure import available_measure_functions
 from btk.measure import MeasureGenerator
 from btk.metrics import MetricsGenerator
-from btk.survey import _get_survey_from_cfg
+from btk.survey import get_survey_from_cfg
 
 
 def main(cfg: OmegaConf):
     """Run BTK from end-to-end using a hydra configuration object."""
-    surveys = [_get_survey_from_cfg(cfg.surveys[survey_name]) for survey_name in cfg.surveys]
+    surveys = [get_survey_from_cfg(cfg.surveys[survey_name]) for survey_name in cfg.surveys]
 
     # get draw blends generator.
     draw_blend_generator = instantiate(cfg.draw_blends, surveys=surveys)

--- a/btk/survey.py
+++ b/btk/survey.py
@@ -63,7 +63,7 @@ Args:
     extinction (float): Exponential extinction coefficient for atmospheric absorption"""
 
 
-def _get_survey_from_cfg(survey_conf: OmegaConf):
+def get_survey_from_cfg(survey_conf: OmegaConf):
     """Creates the corresponding `btk.survey.Survey` object using the information from config file.
 
     Args:
@@ -129,7 +129,7 @@ def get_surveys(names="Rubin", overrides: Iterable = ()):
         cfg = compose("config", overrides=overrides)
     for survey_name in cfg.surveys:
         survey_conf = cfg.surveys[survey_name]
-        surveys.append(_get_survey_from_cfg(survey_conf))
+        surveys.append(get_survey_from_cfg(survey_conf))
     if len(surveys) == 1:
         return surveys[0]
     return surveys

--- a/notebooks/02b-custom-tutorial.ipynb
+++ b/notebooks/02b-custom-tutorial.ipynb
@@ -337,7 +337,7 @@
     "- psf: PSF for the filter. This can be provided in two ways:\n",
     "    - Providing a Galsim PSF model, e.g. `galsim.Kolmogorov(fwhm)` or any convolution of such models.\n",
     "    - Providing a function which returns a Galsim model when called (with no arguments). This can be used when you \n",
-    "      you want to randomize the PSF. More on that in the example below.\n",
+    "      you want to randomize the PSF.\n",
     "    In the case of the default surveys, we only use the first possibility, computing the model using the get_psf function beforehand; those models have an atmospheric and an optical component.\n",
     "\n",
     "Surveys are usually imported using `btk.survey.get_surveys(survey_names)`, which will create the Survey object(s) from a config file (currently, the implemented surveys are Rubin, HSC, HST, Euclid, DES and CFHT); it is also possible to create them directly in Python.\n",


### PR DESCRIPTION
Closes #235 

This is already done consistently by using the `get_survey_from_cfg` function which internally uses the `get_psf` function in `main.py`. Notebooks like the "custom tutorial" correctly demonstrate how to customize.