### PR TITLE
Fix galcheat in BTK and separate PSF from filter/surveys

### DIFF
--- a/btk/draw_blends.py
+++ b/btk/draw_blends.py
@@ -3,8 +3,9 @@ import copy
 import os
 from abc import ABC
 from abc import abstractmethod
-from collections.abc import Iterable
 from itertools import chain
+from typing import List
+from typing import Tuple
 
 import galcheat
 import galsim
@@ -180,7 +181,7 @@ class DrawBlendsGenerator(ABC):
         self.max_number = self.blend_generator.max_number
 
         # get surveys from galcheat.
-        if not isinstance(surveys, Iterable):
+        if not isinstance(surveys, (List, Tuple)):
             surveys = [surveys]
 
         self.surveys = []

--- a/btk/draw_blends.py
+++ b/btk/draw_blends.py
@@ -186,7 +186,10 @@ class DrawBlendsGenerator(ABC):
         self.surveys = []
         for s in surveys:
             if not isinstance(s, str):
-                raise TypeError(f"One of the surveys specified is not a string but type {type(s)}")
+                raise TypeError(
+                    f"The arguments `surveys` should be a string or a list of strings,"
+                    f"but one element was of type {type(s)}"
+                )
             survey = galcheat.get_suvey(s)
             self.check_compatibility(survey)
             self.surveys.append(survey)

--- a/btk/draw_blends.py
+++ b/btk/draw_blends.py
@@ -145,7 +145,7 @@ class DrawBlendsGenerator(ABC):
             catalog (btk.catalog.Catalog): BTK catalog object from which galaxies are taken.
             sampling_function (btk.sampling_function.SamplingFunction): BTK sampling
                 function to use.
-            surveys (str or list of str): List of galcheat survey names or a single survey name.
+            surveys: List of galcheat survey names or galcheat instances or single str/instances.
             batch_size (int): Number of blends generated per batch
             stamp_size (float): Size of the stamps, in arcseconds
             cpus (int): Number of cpus to use; defines the number of minibatches
@@ -185,12 +185,16 @@ class DrawBlendsGenerator(ABC):
 
         self.surveys = []
         for s in surveys:
-            if not isinstance(s, str):
+            if not isinstance(s, (str, galcheat.survey.Survey)):
                 raise TypeError(
-                    f"The arguments `surveys` should be a string or a list of strings,"
-                    f"but one element was of type {type(s)}"
+                    "The arguments `surveys` should be a string or galcheat survey instance or a"
+                    "list of strings or galcheat survey instances.but one element was of type"
+                    f"{type(s)}"
                 )
-            survey = galcheat.get_survey(s)
+            if isinstance(s, str):
+                survey = galcheat.get_survey(s)
+            else:
+                survey = s
             self.check_compatibility(survey)
             self.surveys.append(survey)
         self.is_multiresolution = len(self.surveys) > 1

--- a/btk/main.py
+++ b/btk/main.py
@@ -7,14 +7,13 @@ from omegaconf import OmegaConf
 from btk.measure import available_measure_functions
 from btk.measure import MeasureGenerator
 from btk.metrics import MetricsGenerator
-from btk.survey import get_surveys
 
 
 def main(cfg: OmegaConf):
     """Run BTK from end-to-end using a hydra configuration object."""
     catalog = instantiate(cfg.catalog)
     sampling_function = instantiate(cfg.sampling)
-    surveys = get_surveys(list(cfg.surveys))
+    surveys = list(cfg.surveys)
 
     # get draw blends generator.
     draw_blend_generator = instantiate(cfg.draw_blends, catalog, sampling_function, surveys)

--- a/btk/survey.py
+++ b/btk/survey.py
@@ -1,56 +1,12 @@
 """Contains information for surveys available in BTK."""
 import os
 import random as rd
-from typing import Callable
-from typing import List
-from typing import Union
 
 import astropy.wcs as WCS
 import galcheat
 import galsim
 import numpy as np
 from astropy.io import fits
-from galcheat.survey import Survey
-
-
-def get_surveys(names: Union[Survey, List[Survey]], psf_func: Callable = None):
-    """Return specified surveys from galcheat extended to contain PSF information.
-
-    This function currently returns a list of galcheat instances if `names` is a list with more
-    than one element. If `names` is a str or a singleton list then we return a single galcheat
-    instance.
-
-    Args:
-        names (str or list): A single str specifying a survey from conf/surveys or a list with
-            multiple survey names.
-        psf_func (function): Python function which takes in two arguments: `survey` and `filter`
-            that returns a PSF as a galsim object or as a callable with no arguments.
-            If `None`, the default PSF for the specified survey will be used in each band.
-
-    Returns:
-        galcheat.survey.Survey object or list of such objects.
-    """
-    if isinstance(names, str):
-        names = [names]
-    if not isinstance(names, list):
-        raise TypeError("Argument 'names' of `get_surveys` should be a str or list.")
-
-    # add PSF to filters
-    surveys = []
-    for survey_name in names:
-        survey = galcheat.get_survey(survey_name)
-        for band in survey.available_filters:
-            filtr = survey.get_filter(band)
-            if psf_func is None:
-                psf = get_default_psf_with_galcheat_info(survey, filtr)
-            else:
-                psf = psf_func(survey, filtr)
-            filtr.psf = psf
-        surveys.append(survey)
-
-    if len(surveys) == 1:
-        surveys = surveys[0]
-    return surveys
 
 
 def get_default_psf_with_galcheat_info(

--- a/tests/test_cosmos.py
+++ b/tests/test_cosmos.py
@@ -1,9 +1,10 @@
+import galcheat
 from conftest import data_dir
 
 from btk.catalog import CosmosCatalog
 from btk.draw_blends import CosmosGenerator
 from btk.sampling_functions import DefaultSampling
-from btk.survey import get_surveys
+
 
 COSMOS_CATALOG_PATHS = [
     str(data_dir / "cosmos/real_galaxy_catalog_23.5_example.fits"),
@@ -21,12 +22,11 @@ def test_cosmos_galaxies_real():
     batch_size = 2
     catalog = CosmosCatalog.from_file(COSMOS_CATALOG_PATHS)
     sampling_function = DefaultSampling(stamp_size=stamp_size)
-    COSMOS = get_surveys("COSMOS")
 
     draw_generator = CosmosGenerator(
         catalog,
         sampling_function,
-        COSMOS,
+        "COSMOS",
         batch_size=batch_size,
         stamp_size=stamp_size,
         cpus=1,
@@ -43,12 +43,11 @@ def test_cosmos_galaxies_parametric():
     batch_size = 2
     catalog = CosmosCatalog.from_file(COSMOS_CATALOG_PATHS)
     sampling_function = DefaultSampling(stamp_size=stamp_size)
-    COSMOS = get_surveys("COSMOS")
 
     draw_generator = CosmosGenerator(
         catalog,
         sampling_function,
-        COSMOS,
+        "COSMOS",
         batch_size=batch_size,
         stamp_size=stamp_size,
         cpus=1,
@@ -65,7 +64,7 @@ def test_cosmos_ext_galaxies():
     batch_size = 2
     catalog = CosmosCatalog.from_file(COSMOS_EXT_CATALOG_PATHS, exclusion_level="none")
     sampling_function = DefaultSampling(stamp_size=stamp_size)
-    COSMOS = get_surveys("COSMOS")
+    COSMOS = galcheat.get_survey("COSMOS")
 
     draw_generator = CosmosGenerator(
         catalog,

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -5,7 +5,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import btk.plot_utils
-from btk.survey import get_surveys
 
 TEST_SEED = 0
 
@@ -43,7 +42,7 @@ def get_draw_generator(
     draw_generator = btk.draw_blends.CatsimGenerator(
         catalog,
         sampling_function,
-        get_surveys("LSST"),
+        "LSST",
         batch_size=batch_size,
         stamp_size=stamp_size,
         shifts=shifts,

--- a/tests/test_error_cases.py
+++ b/tests/test_error_cases.py
@@ -1,3 +1,4 @@
+import galcheat
 import pytest
 from conftest import data_dir
 from galcheat.filter import Filter
@@ -11,9 +12,7 @@ from btk.draw_blends import SourceNotVisible
 from btk.sampling_functions import DefaultSampling
 from btk.sampling_functions import SamplingFunction
 from btk.survey import get_default_psf
-from btk.survey import get_default_psf_with_galcheat_info
 from btk.survey import get_psf_from_file
-from btk.survey import get_surveys
 
 CATALOG_PATH = data_dir / "sample_input_catalog.fits"
 
@@ -51,7 +50,7 @@ def test_sampling_no_max_number():
         draw_generator = CatsimGenerator(
             catalog,
             sampling_function,
-            get_surveys("LSST"),
+            "LSST",
             stamp_size=stamp_size,
             batch_size=batch_size,
             cpus=cpus,
@@ -82,7 +81,7 @@ def test_sampling_incompatible_catalog():
         draw_generator = CatsimGenerator(
             catalog,
             sampling_function,
-            get_surveys("LSST"),
+            "LSST",
             stamp_size=stamp_size,
             batch_size=batch_size,
             cpus=cpus,
@@ -118,7 +117,7 @@ def test_sampling_too_much_objects():
         draw_generator = CatsimGenerator(
             catalog,
             sampling_function,
-            get_surveys("LSST"),
+            "LSST",
             stamp_size=stamp_size,
             batch_size=batch_size,
             cpus=cpus,
@@ -130,7 +129,6 @@ def test_sampling_too_much_objects():
 
 
 def test_source_not_visible():
-    survey = get_surveys("LSST")
     filt = Filter.from_dict(
         dict(
             name="u",
@@ -141,7 +139,7 @@ def test_source_not_visible():
             effective_wavelength=3592.13,
         )
     )
-    filt.psf = get_default_psf_with_galcheat_info(survey, filt)
+    survey = galcheat.get_survey("LSST")
     catalog = CatsimCatalog.from_file(CATALOG_PATH)
     with pytest.raises(SourceNotVisible):
         get_catsim_galaxy(catalog.table[0], filt, survey, True, True, True)
@@ -214,8 +212,8 @@ def test_psf():
 
     get_default_psf(mirror_diameter=0, effective_area=0, filt_wavelength=7528.51, fwhm=0.748)
 
-    get_psf_from_file("tests/example_psf", get_surveys("LSST"))
-    get_psf_from_file("tests/multi_psf", get_surveys("LSST"))
+    get_psf_from_file("tests/example_psf", galcheat.get_survey("LSST"))
+    get_psf_from_file("tests/multi_psf", galcheat.get_survey("LSST"))
     # The case where the folder is empty cannot be tested as you cannot add an empty folder to git
 
 
@@ -232,7 +230,7 @@ def test_incompatible_catalogs():
         draw_generator = CosmosGenerator(  # noqa: F841
             catalog,
             sampling_function,
-            get_surveys("LSST"),
+            "LSST",
             stamp_size=stamp_size,
             batch_size=batch_size,
             cpus=cpus,
@@ -243,7 +241,7 @@ def test_incompatible_catalogs():
         CatsimGenerator(
             catalog,
             sampling_function,
-            get_surveys("COSMOS"),
+            "COSMOS",
             stamp_size=stamp_size,
             batch_size=batch_size,
             cpus=cpus,
@@ -255,7 +253,7 @@ def test_incompatible_catalogs():
         CatsimGenerator(
             catalog,
             sampling_function,
-            get_surveys("LSST"),
+            "LSST",
             stamp_size=stamp_size,
             batch_size=batch_size,
             cpus=cpus,

--- a/tests/test_group_sampling.py
+++ b/tests/test_group_sampling.py
@@ -4,7 +4,6 @@ from conftest import data_dir
 from btk.catalog import CatsimCatalog
 from btk.draw_blends import CatsimGenerator
 from btk.sampling_functions import GroupSamplingNumbered
-from btk.survey import get_surveys
 
 TEST_SEED = 0
 
@@ -16,7 +15,6 @@ def get_group_sampling_draw_generator(batch_size=3):
 
     max_number = 10
     stamp_size = 24
-    survey = get_surveys("LSST")
     pixel_scale = 0.2
     shift = [0.8, -0.7]
     catalog = CatsimCatalog.from_file(catalog_name)
@@ -24,7 +22,7 @@ def get_group_sampling_draw_generator(batch_size=3):
         max_number, wld_catalog_name, stamp_size, pixel_scale, shift=shift, seed=TEST_SEED
     )
     draw_blend_generator = CatsimGenerator(
-        catalog, sampling_function, [survey], batch_size=batch_size, seed=TEST_SEED
+        catalog, sampling_function, ["LSST"], batch_size=batch_size, seed=TEST_SEED
     )
     return draw_blend_generator
 

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -6,7 +6,6 @@ from btk.draw_blends import CatsimGenerator
 from btk.measure import MeasureGenerator
 from btk.measure import sep_measure
 from btk.sampling_functions import DefaultSampling
-from btk.survey import get_surveys
 
 TEST_SEED = 0
 
@@ -16,14 +15,13 @@ def get_meas_results(meas_function, cpus=1, measure_kwargs=None):
 
     catalog_name = data_dir / "sample_input_catalog.fits"
     stamp_size = 24
-    survey = get_surveys("LSST")
     shifts = [[-0.3, 1.2]]
     indexes = [[1]]
     catalog = CatsimCatalog.from_file(catalog_name)
     draw_blend_generator = CatsimGenerator(
         catalog,
         DefaultSampling(seed=TEST_SEED),
-        [survey],
+        ["LSST"],
         shifts=shifts,
         indexes=indexes,
         stamp_size=stamp_size,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -13,7 +13,6 @@ from btk.metrics import get_detection_eff_matrix
 from btk.metrics import meas_ksb_ellipticity
 from btk.metrics import MetricsGenerator
 from btk.sampling_functions import DefaultSampling
-from btk.survey import get_surveys
 
 
 TEST_SEED = 0
@@ -27,7 +26,6 @@ def get_metrics_generator(
     """Returns draw generator with group sampling function"""
     catalog_name = "data/sample_input_catalog.fits"
     stamp_size = 24
-    survey = get_surveys("LSST")
     shifts = [
         [[-0.3, 1.2], [-1.6, -1.7]],
         [[-1.1, -2.1], [1.4, 1.8]],
@@ -43,7 +41,7 @@ def get_metrics_generator(
     draw_blend_generator = CatsimGenerator(
         catalog,
         DefaultSampling(seed=TEST_SEED),
-        [survey],
+        ["LSST"],
         shifts=shifts,
         indexes=indexes,
         stamp_size=stamp_size,

--- a/tests/test_mr.py
+++ b/tests/test_mr.py
@@ -10,7 +10,6 @@ from btk.metrics import meas_ksb_ellipticity
 from btk.metrics import MetricsGenerator
 from btk.plot_utils import plot_metrics_summary
 from btk.sampling_functions import DefaultSampling
-from btk.survey import get_surveys
 
 
 @patch("btk.plot_utils.plt.show")
@@ -21,14 +20,13 @@ def test_multiresolution(mock_show):
     batch_size = 8
     cpus = 1
     add_noise = "all"
-    surveys = get_surveys(["LSST", "HSC"])
 
     catalog = CatsimCatalog.from_file(catalog_name)
     sampling_function = DefaultSampling(stamp_size=stamp_size)
     draw_blend_generator = CatsimGenerator(
         catalog,
         sampling_function,
-        surveys,
+        ["LSST", "HSC"],
         stamp_size=stamp_size,
         batch_size=batch_size,
         cpus=cpus,

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -9,7 +9,6 @@ from btk.measure import sep_measure
 from btk.metrics import meas_ksb_ellipticity
 from btk.metrics import MetricsGenerator
 from btk.sampling_functions import DefaultSampling
-from btk.survey import get_surveys
 from btk.utils import load_all_results
 
 
@@ -23,7 +22,7 @@ def test_save():
     draw_blend_generator = CatsimGenerator(
         catalog,
         sampling_function,
-        get_surveys("LSST"),
+        "LSST",
         batch_size=batch_size,
         stamp_size=stamp_size,
         save_path=output_dir,


### PR DESCRIPTION
After discussing with @aboucaud [here](https://github.com/aboucaud/galcheat/issues/108), I did some more thinking and  realized that perhaps making the galcheat classes extendable in BTK is not the highest priority. It definitely adds some complexity on both sides (BTK and galcheat) and I remember from a previous BTK meeting that allowing users to change survey configurations is not so useful at the moment. 

In this PR I propose to separate the PSF from survey/filter objects which actually simplifies the code greatly since we can simply use the galcheat classes as is. I think this is also more user friendly and less confusing. Separating out the PSF was actually really simple and now there is less to check (unless I missed something?) 

I'm open to suggestions or comments on this @aboucaud / @thuiop 